### PR TITLE
T 7.4 Kommentare chronologisch anzeigen

### DIFF
--- a/client/src/components/BlipDetailSheetComponent.jsx
+++ b/client/src/components/BlipDetailSheetComponent.jsx
@@ -102,7 +102,21 @@ class BlipDetailSheetComponent extends React.Component {
     }
 
     render() {
-        var commentListItems = this.state.comments.map(function (item) {
+        var commentListItems = this.state.comments
+            .sort(function compare(a, b) {
+                var partsA =a.zeit.split(', ');
+                var datesA = partsA[0].split('/');
+                var timeA = partsA[1].split(':');
+                var dateA = new Date('20' + datesA[2], datesA[1], datesA[0], timeA[0], timeA[1], timeA[2]);
+
+                var partsB =b.zeit.split(', ');
+                var datesB = partsB[0].split('/');
+                var timeB = partsB[1].split(':');
+                var dateB = new Date('20' + datesB[2], datesB[1], datesB[0], timeB[0], timeB[1], timeB[2]);
+
+                return dateA - dateB;
+            })
+            .map(function (item) {
             return (
                 <div>{item.autor} | {item.text} | {item.status} | {item.zeit} </div>
             );


### PR DESCRIPTION
die sortierung der kommentare kann man nur sehen, wenn die generierten kommentare schon da sind, weil sonst das date format zum teil nicht stimmt. da man nach wie vor nicht scrollen kann und viele kommentare den gleichen timstamp haben, ist es nicht auf den ersten blick ersichtlich dass die sortierung richtig ist, aber weiter unten kommen dann auch anderen uhrzeiten und daten (einfach mal bisschen rauszoomen, dann sieht man's) bzw. ich hab's mir auch mit filterung angeguckt und da sah's auch gut aus.

- [x] first merge https://github.com/cosmoem/tech-radar-htw/pull/10

- [x] then retarget to `master`