### PR TITLE
T 9.4: Zeichenlimit Kommentarfeld 

### DIFF
--- a/client/src/components/BlipDetailSheetComponent.jsx
+++ b/client/src/components/BlipDetailSheetComponent.jsx
@@ -182,7 +182,7 @@ class BlipDetailSheetComponent extends React.Component {
                 <div>{error}</div>
                 <div className="discussionContainer">
                     {this.getDropdownStatus()}
-                    <span><input type="text" value={this.state.newCommentText}
+                    <span><input type="text" maxLength="500" value={this.state.newCommentText}
                            onChange={this.handleChange} className="inputText"/>
                     <Button size="large" color="primary" onClick={this.addNewComment} className="sendButton">
                         Senden


### PR DESCRIPTION
Zeichenlimit fürs Kommentarfeld eingefügt. Nach 500 Zeichen kann man nicht mehr weitertippen.